### PR TITLE
Add timeout for read timeout error

### DIFF
--- a/lib/blue_apron/spree_client.rb
+++ b/lib/blue_apron/spree_client.rb
@@ -236,7 +236,7 @@ module BlueApron
       end
 
       def setup_timeouts(request)
-        #request.options.timeout = 10
+        request.options.timeout = timeout
         request.options.open_timeout = timeout
       end
 


### PR DESCRIPTION
This one's been popping up on and off for over a year ([rollbar](https://rollbar.com/blueapron/blueapron.com/items/7307)). `TimeoutError` is coming from Faraday not being able to read data from the http object within the default timeout period of 2s. The current `open_timeout` just handles the time taken to open the connection.

Thoughts on whether this will improve matters?

/cc: @HoyaBoya 
/cc: @blueapron/ba-backend 