### PR TITLE
Revert timeout increase

### DIFF
--- a/lib/blue_apron/spree_client.rb
+++ b/lib/blue_apron/spree_client.rb
@@ -236,7 +236,7 @@ module BlueApron
       end
 
       def setup_timeouts(request)
-        request.options.timeout = timeout
+        # request.options.timeout = timeout
         request.options.open_timeout = timeout
       end
 


### PR DESCRIPTION
Lengthening the read timeout in #7 is [interacting badly](https://rollbar.com/blueapron/blueapron.com/items/7338/) with the Net::Http client. Reverting the change for now.

/cc: @HoyaBoya 
/cc: @blueapron/ba-backend 